### PR TITLE
Rework table resolver maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,33 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### 1.63.0-rc.1 (2020-09-24)
+## 1.63.0-rc.2 (2020-09-30)
+
+### Bugfixes
+
+* Fixed a bug with @key directive where it wouldn't properly create resolvers when the @key had a custom query field
+  * Cleaned up the way resolvers are mapped to tables
+
+## 1.63.0-rc.1 (2020-09-24)
 
 ### Updates / Bugfixes
 
 * Updating for changes to CDK v1.63+
 
-### 1.50.0-rc.1 (2020-08-30)
+## 1.50.0-rc.1 (2020-08-30)
 
 ### Features
 
 * Adding in experimental support for function directives. See README for details.
 
-### 1.50.0-alpha (2020-07-07)
+## 1.50.0-alpha (2020-07-07)
 
 ### Bugfixes
 
 * Fixed circular reference with the nested stack
 * Changed scope of the `appsyncGraphQLEndpointOutput` to correctly be the main stack
 
-### 1.49.1-alpha (2020-07-06)
+## 1.49.1-alpha (2020-07-06)
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Auth Role: Unsupported (for now?). Authorized roles (Lambda Functions, EC2 roles
 
 ### Functions
 
-Fields with the `@function` direction will be accessible via `api.outputs.FUNCTION_RESOLVERS`. It will return an array like below.Currently these are not named and do not specify a region. There are improvements that can be made here but this simple way has worked for me so I've implemented it first. Typically I send all `@function` requests to one Lambda Function and have it route as necessary.
+Fields with the `@function` directive will be accessible via `api.outputs.FUNCTION_RESOLVERS`. It will return an array like below.Currently these are not named and do not specify a region. There are improvements that can be made here but this simple way has worked for me so I've implemented it first. Typically I send all `@function` requests to one Lambda Function and have it route as necessary.
 
 ```js
 [

--- a/lib/transformer/schema-transformer.ts
+++ b/lib/transformer/schema-transformer.ts
@@ -144,8 +144,6 @@ export class SchemaTransformer {
                     } else if (templateType === 'res') {
                         this.resolvers['gsi'][mapName]['responseMappingTemplate'] = filepath
                     }
-
-
                 }
             })
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-cdk-appsync-transformer",
-  "version": "1.63.0-rc.1",
+  "version": "1.63.0-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-cdk-appsync-transformer",
-  "version": "1.63.0-rc.1",
+  "version": "1.63.0-rc.2",
   "description": "AWS Amplify inspired CDK construct for creating @directive based AppSync APIs",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -24,8 +24,6 @@ test('GraphQL API W/ Defaults Created', () => {
         authorizationConfig: apiKeyAuthorizationConfig
     });
 
-    console.log(stack);
-
     expect(stack).toHaveResource('AWS::CloudFormation::Stack');
     expect(appSyncTransformer.nestedAppsyncStack).toHaveResource('AWS::AppSync::GraphQLApi', {
         AuthenticationType: 'API_KEY'


### PR DESCRIPTION
* Fixed a bug with @key directive where it wouldn't properly create resolvers when the @key had a custom query field
* Cleaned up the way resolvers are mapped to tables

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

Please read the contribution guidelines and follow the pull-request checklist:
https://github.com/kcwinner/appsync-transformer-construct/blob/main/CONTRIBUTING.md